### PR TITLE
NLogEtwExtendedTarget - Added support for providing own EventSource 

### DIFF
--- a/NLog.Etw/INLogEventSource.cs
+++ b/NLog.Etw/INLogEventSource.cs
@@ -1,0 +1,35 @@
+﻿#if NET45
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+
+namespace NLog.Etw
+{
+    /// <summary>
+    /// Allows custom <see cref="EventSource"/> to be used with <see cref="NLogEtwExtendedTarget"/>
+    /// 
+    /// Receives NLog <see cref="LogEventInfo"/> for writing to custom <see cref="EventSource"/> methods to ETW
+    /// </summary>
+    public interface INLogEventSource
+    {
+        /// <summary>
+        /// Returns the real EventSource
+        /// </summary>
+        /// <remarks>
+        /// The custom EventSource implementing this interface-property should just return this (or static instance)
+        /// </remarks>
+        EventSource EventSource { get; }
+
+        /// <summary>
+        /// Write NLog LogEvent to ETW 
+        /// </summary>
+        /// <remarks>
+        /// The custom EventSource implementing this interface-method should mark the method with attribute [NonEvent]
+        /// </remarks>
+        /// <param name="eventLevel"></param>
+        /// <param name="layoutMessage"></param>
+        /// <param name="logEvent"></param>
+        void Write(EventLevel eventLevel, string layoutMessage, LogEventInfo logEvent);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Add the assembly and new target to NLog.config:
     <targets async="true">
         <target xsi:type="EtwEventSource"
                 name="eetw"
-				providerName="MyEventSourceName"
-				taskName="${level}"
+                providerName="MyEventSourceName"
+                taskName="${level}"
                 layout="${message}"
               />
     </targets>
@@ -44,4 +44,28 @@ Add the assembly and new target to NLog.config:
       <logger name="*" minlevel="Trace" writeTo="eetw" />
     </rules>
 </nlog>
+```
+
+#### Write to own custom EventSource
+
+```c#
+[EventSource(Name = "MyEventSourceName")]
+public class MyEventSource : EventSource, NLog.Etw.INLogEventSource
+{
+    /// <inheritdoc/>
+    [NonEvent]
+    public void Write(EventLevel eventLevel, string layoutMessage, LogEventInfo logEvent)
+    {
+        // TODO Call own custom logging-method
+    }
+
+    /// <inheritdoc/>
+    EventSource EventSource { get { return this; } }
+
+    internal readonly static MyEventSource Log = new MyEventSource();
+}
+
+var config = new NLog.Config.LoggingConfiguration();
+config.AddRuleForAllLevels(new NLog.Etw.NLogEtwExtendedTarget(MyEventSource.Log) { Name = "eetw" });
+NLog.LogManager.Configuration = config;
 ```


### PR DESCRIPTION
When the EventSource implements `NLogEtwExtendedTarget.INLogEventSource`